### PR TITLE
Added test for auth.

### DIFF
--- a/src/AndroidClient/client/src/androidTest/java/net/servicestack/client/tests/TestServiceTests.java
+++ b/src/AndroidClient/client/src/androidTest/java/net/servicestack/client/tests/TestServiceTests.java
@@ -178,16 +178,17 @@ public class TestServiceTests extends ApplicationTestCase<Application> {
 
     public void test_does_handle_auth_failure() {
         JsonServiceClient techStacksClient = new JsonServiceClient("http://techstacks.io/");
-        String errorCode = "";
+        int errorCode = 0;
         try {
             dto.LockTechStack request = new dto.LockTechStack();
             request.setTechnologyStackId((long)6);
             dto.LockStackResponse res = techStacksClient.post(request);
+            fail("Should throw");
         } catch(WebServiceException ex) {
             //private StatusCode has correct code, response status is null due to empty response body.
-            errorCode = ex.getResponseStatus().errorCode;
+            errorCode = ex.getStatusCode();
         }
-        assertEquals(errorCode,"401");
+        assertEquals(errorCode,401);
     }
 
     /* TEST HELPERS */

--- a/src/AndroidClient/client/src/main/java/net/servicestack/client/Utils.java
+++ b/src/AndroidClient/client/src/main/java/net/servicestack/client/Utils.java
@@ -10,7 +10,6 @@ import com.google.gson.JsonParseException;
 
 import org.apache.http.util.ByteArrayBuffer;
 
-
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -27,12 +26,12 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static net.servicestack.client.Func.*;
+import static net.servicestack.client.Func.Function;
+import static net.servicestack.client.Func.last;
 
 // Generic Utils
 public class Utils {

--- a/src/AndroidClient/client/src/main/java/net/servicestack/client/WebServiceException.java
+++ b/src/AndroidClient/client/src/main/java/net/servicestack/client/WebServiceException.java
@@ -39,6 +39,14 @@ public class WebServiceException extends RuntimeException {
         return ResponseStatus != null ? ResponseStatus.stackTrace : null;
     }
 
+    public int getStatusCode() {
+        return this.StatusCode;
+    }
+
+    public String getStatusDescription() {
+        return this.StatusDescription;
+    }
+
     public ArrayList<ResponseError> getFieldErrors(){
         ArrayList<ResponseError> fieldErrors = ResponseStatus != null
             ? ResponseStatus.getErrors()


### PR DESCRIPTION
Exposed status code from WebServiceException as 401 errors don't return a body.

@mythz these are exposed in the .NET WebServiceException used by the JsonServiceClient, just wanted to make sure this makes sense and you didn't need to keep the exception status code private for a reason.
