### PR TITLE
re-authenticate before creating request to avoid 'already connected' …

### DIFF
--- a/src/AndroidClient/client/src/main/java/net/servicestack/client/JsonServiceClient.java
+++ b/src/AndroidClient/client/src/main/java/net/servicestack/client/JsonServiceClient.java
@@ -136,6 +136,11 @@ public class JsonServiceClient implements ServiceClient {
     }
 
     public HttpURLConnection createRequest(String requestUrl, String httpMethod, byte[] requestBody, String requestType) {
+    	return createRequest(requestUrl, httpMethod, requestBody, requestType, false);
+    
+    }
+    
+    public HttpURLConnection createRequest(String requestUrl, String httpMethod, byte[] requestBody, String requestType, Boolean forceAuthentication) {
         try {
             URL url = new URL(requestUrl);
 
@@ -153,7 +158,7 @@ public class JsonServiceClient implements ServiceClient {
                 req.setRequestProperty(HttpHeaders.ContentType, requestType);
             }
 
-            if (alwaysSendBasicAuthHeaders) {
+            if (forceAuthentication || alwaysSendBasicAuthHeaders) {
                 addBasicAuth(req, userName, password);
             }
 
@@ -336,8 +341,8 @@ public class JsonServiceClient implements ServiceClient {
 
                 if (shouldAuthenticate(req, userName, password)){
                     req.disconnect();
-                    req = createRequest(requestUrl, httpMethod, requestBody, requestType);
-                    addBasicAuth(req, userName, password);
+                    req = createRequest(requestUrl, httpMethod, requestBody, requestType, true);
+                  
                     success = req.getResponseCode() < 400;
                 }
 

--- a/src/AndroidClient/client/src/test/java/net/servicestack/client/TestAuthTests.java
+++ b/src/AndroidClient/client/src/test/java/net/servicestack/client/TestAuthTests.java
@@ -35,16 +35,32 @@ public class TestAuthTests extends TestCase {
         assertNotNull(response.getSessionId());
     }
 
-    public void test_does_transparently_send_BasicAuthHeader_on_401_response(){
+    private void does_transparently_send_BasicAuthHeader_on_401(Boolean isPost){
         ServiceClient client = CreateClient();
         client.setCredentials("test", "test");
-
-        testdtos.TestAuthResponse response = client.get(new testdtos.TestAuth());
-
+        
+        testdtos.TestAuthResponse response = null;
+        if (isPost) {
+        	response = client.post(new testdtos.TestAuth());
+        } else {
+        	response = client.get(new testdtos.TestAuth());
+        }
         assertEquals("1", response.getUserId());
         assertEquals("test", response.getUserName());
         assertEquals("test DisplayName", response.getDisplayName());
         assertNotNull(response.getSessionId());
+    }
+    
+    public void test_does_transparently_send_BasicAuthHeader_on_401_response_From_get(){
+        
+    	does_transparently_send_BasicAuthHeader_on_401( false);
+
+    }
+    
+    public void test_does_transparently_send_BasicAuthHeader_on_401_response_from_post(){
+    	
+    	does_transparently_send_BasicAuthHeader_on_401( true);
+
     }
 
     public void test_can_authenticate_with_CredentialsAuth(){


### PR DESCRIPTION
The feature to transparently send the basic credentials on a 401 response fails on a POST as the call to getOutputStream connects the HttpURLConnection, leading to a later error (already connected) when we attempt to authenticate.

To get around this I forceAuthentication prior to calling getOutputStream.